### PR TITLE
Fix "misconfigured L1 Beacon API endpoint: expected L1 Beacon API endpoint, but got none"

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
-# [recommended] replace with your preferred L1 (Ethereum, not Conduit) node RPC URL:
+# replace with your preferred L1 (Ethereum, not Conduit) node RPC URL:
 OP_NODE_L1_ETH_RPC=http://l1rpc
+# replace with your preferred L1 (Ethereum, not Conduit) node Beacon URL:
+OP_NODE_L1_BEACON=http://l1beacon


### PR DESCRIPTION
The latest update requires a L1 Beacon API endpoint to be set. However, this is not explained yet in the Readme nor included in the example .env
This PR is to clarify and fix issues https://github.com/conduitxyz/node/issues/37 and https://github.com/conduitxyz/node/issues/38